### PR TITLE
SuperVanish/PremiumVanish support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.idea
+*.class
+/target
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,23 @@
 			<id>jitpack.io</id>
 			<url>https://jitpack.io</url>
 		</repository>
+		<repository>
+			<id>nexus-snapshots</id>
+			<url>https://services.mind-overflow.net/nexus/repository/maven-releases/</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.bukkit</groupId>
-			<artifactId>craftbukkit</artifactId>
-			<version>1.12.2-R0.1-SNAPSHOT</version>
+			<groupId>org.spigotmc</groupId>
+			<artifactId>spigot-api</artifactId>
+			<version>1.17.1-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.LeonMangler</groupId>
+			<artifactId>PremiumVanishAPI</artifactId>
+			<version>2.7.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.MilkBowl</groupId>
@@ -72,8 +81,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 				</configuration>
 			</plugin>
 			<!-- Sets the custom JARfile name (Project name without spaces is good) -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.17.1-R0.1-SNAPSHOT</version>
+			<version>1.12.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/de/Linus122/Handlers/VanishHandler.java
+++ b/src/main/java/de/Linus122/Handlers/VanishHandler.java
@@ -1,0 +1,44 @@
+package de.Linus122.Handlers;
+
+import de.Linus122.Telegram.Utils;
+import de.Linus122.TelegramChat.TelegramChat;
+import de.Linus122.TelegramComponents.ChatMessageToTelegram;
+import de.myzelyam.api.vanish.PlayerHideEvent;
+import de.myzelyam.api.vanish.PlayerShowEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class VanishHandler implements Listener
+{
+
+    @EventHandler
+    public void onVanish(PlayerHideEvent e) {
+        Player p = e.getPlayer();
+        if(e.isCancelled()) return;
+
+        if (!TelegramChat.getInstance().getConfig().getBoolean("enable-joinquitmessages"))
+            return;
+        if (TelegramChat.telegramHook.connected) {
+            ChatMessageToTelegram chat = new ChatMessageToTelegram();
+            chat.parse_mode = "Markdown";
+            chat.text = Utils.formatMSG("quit-message", e.getPlayer().getName())[0];
+            TelegramChat.telegramHook.sendAll(chat);
+        }
+    }
+
+    @EventHandler
+    public void onShow(PlayerShowEvent e) {
+        Player p = e.getPlayer();
+        if(e.isCancelled()) return;
+
+        if (!TelegramChat.getInstance().getConfig().getBoolean("enable-joinquitmessages"))
+            return;
+        if (TelegramChat.telegramHook.connected) {
+            ChatMessageToTelegram chat = new ChatMessageToTelegram();
+            chat.parse_mode = "Markdown";
+            chat.text = Utils.formatMSG("join-message", e.getPlayer().getName())[0];
+            TelegramChat.telegramHook.sendAll(chat);
+        }
+    }
+}

--- a/src/main/java/de/Linus122/TelegramChat/TelegramChat.java
+++ b/src/main/java/de/Linus122/TelegramChat/TelegramChat.java
@@ -12,6 +12,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.logging.Level;
 
+import de.Linus122.Handlers.VanishHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -40,16 +41,22 @@ public class TelegramChat extends JavaPlugin implements Listener {
 
 	private static Data data = new Data();
 	public static Telegram telegramHook;
+	private static TelegramChat instance;
 
 	@Override
 	public void onEnable() {
 		this.saveDefaultConfig();
 		cfg = this.getConfig();
+		instance = this;
 		Utils.cfg = cfg;
 
 		Bukkit.getPluginCommand("telegram").setExecutor(new TelegramCmd());
 		Bukkit.getPluginCommand("linktelegram").setExecutor(new LinkTelegramCmd());
 		Bukkit.getPluginManager().registerEvents(this, this);
+
+		if (Bukkit.getPluginManager().isPluginEnabled("SuperVanish") || Bukkit.getPluginManager().isPluginEnabled("PremiumVanish")) {
+			Bukkit.getPluginManager().registerEvents(new VanishHandler(), this);
+		}
 
 		File dir = new File("plugins/TelegramChat/");
 		dir.mkdir();
@@ -236,6 +243,11 @@ public class TelegramChat extends JavaPlugin implements Listener {
 					.replaceAll("§.", "");
 			telegramHook.sendAll(chat);
 		}
+	}
+
+	public static TelegramChat getInstance()
+	{
+		return instance;
 	}
 
 }

--- a/src/main/java/de/Linus122/TelegramChat/TelegramChat.java
+++ b/src/main/java/de/Linus122/TelegramChat/TelegramChat.java
@@ -201,7 +201,7 @@ public class TelegramChat extends JavaPlugin implements Listener {
 		if (!this.getConfig().getBoolean("enable-joinquitmessages"))
 			return;
 
-		if(VanishAPI.isInvisible(e.getPlayer()))
+		if(isSuperVanish && VanishAPI.isInvisible(e.getPlayer()))
 			return;
 
 		if (telegramHook.connected) {
@@ -229,7 +229,7 @@ public class TelegramChat extends JavaPlugin implements Listener {
 		if (!this.getConfig().getBoolean("enable-joinquitmessages"))
 			return;
 
-		if(VanishAPI.isInvisible(e.getPlayer()))
+		if(isSuperVanish && VanishAPI.isInvisible(e.getPlayer()))
 			return;
 
 		if (telegramHook.connected) {

--- a/src/main/java/de/Linus122/TelegramChat/TelegramChat.java
+++ b/src/main/java/de/Linus122/TelegramChat/TelegramChat.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 
 import de.Linus122.Handlers.VanishHandler;
+import de.myzelyam.api.vanish.VanishAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -42,6 +43,7 @@ public class TelegramChat extends JavaPlugin implements Listener {
 	private static Data data = new Data();
 	public static Telegram telegramHook;
 	private static TelegramChat instance;
+	private static boolean isSuperVanish;
 
 	@Override
 	public void onEnable() {
@@ -55,6 +57,7 @@ public class TelegramChat extends JavaPlugin implements Listener {
 		Bukkit.getPluginManager().registerEvents(this, this);
 
 		if (Bukkit.getPluginManager().isPluginEnabled("SuperVanish") || Bukkit.getPluginManager().isPluginEnabled("PremiumVanish")) {
+			isSuperVanish = true;
 			Bukkit.getPluginManager().registerEvents(new VanishHandler(), this);
 		}
 
@@ -197,6 +200,10 @@ public class TelegramChat extends JavaPlugin implements Listener {
 	public void onJoin(PlayerJoinEvent e) {
 		if (!this.getConfig().getBoolean("enable-joinquitmessages"))
 			return;
+
+		if(VanishAPI.isInvisible(e.getPlayer()))
+			return;
+
 		if (telegramHook.connected) {
 			ChatMessageToTelegram chat = new ChatMessageToTelegram();
 			chat.parse_mode = "Markdown";
@@ -221,6 +228,10 @@ public class TelegramChat extends JavaPlugin implements Listener {
 	public void onQuit(PlayerQuitEvent e) {
 		if (!this.getConfig().getBoolean("enable-joinquitmessages"))
 			return;
+
+		if(VanishAPI.isInvisible(e.getPlayer()))
+			return;
+
 		if (telegramHook.connected) {
 			ChatMessageToTelegram chat = new ChatMessageToTelegram();
 			chat.parse_mode = "Markdown";

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: TelegramChat
 main: de.Linus122.TelegramChat.TelegramChat
 version: ${project.version}
 authors: [Linus122]
-softdepend: [Vault]
+softdepend: [Vault, SuperVanish, PremiumVanish]
 description: Brings minecraft chat to Telegram!
 commands:
    telegram:


### PR DESCRIPTION
Previously, players who were using SuperVanish or PremiumVanish were shown join/quit messages in-game, but not on Telegram.
This way, it was potentially possible to know if a player was actually still online, and thus simply vanished.

Since the two vanish plugins share the same nice and simple API, I thought of implementing it directly into TelegramChat and, why not, open this pull request.

I tried to be as neutral as possible in terms of code style and structure, replicating the plugins' one, but if there's anything you want me to change just let me know!