### PR TITLE
adding boolean to disable automated update of chat ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .classpath
 .settings/
 *.prefs
+.vscode/settings.json

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>xyz.spaceio</groupId>
 	<artifactId>telegramchat</artifactId>
-	<version>1.0.21-SNAPSHOT</version>
+	<version>1.0.22-SNAPSHOT</version>
 	<name>TelegramChat</name>
 	<url>https://www.spigotmc.org/resources/telegramchat.16576/</url>
 
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.12.2-R0.1-SNAPSHOT</version>
+			<version>1.21.8-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/de/Linus122/TelegramChat/TelegramChat.java
+++ b/src/main/java/de/Linus122/TelegramChat/TelegramChat.java
@@ -112,7 +112,7 @@ public class TelegramChat extends JavaPlugin implements Listener {
 				if (success)
 					connectionLost = false;
 			}
-			if (telegramHook.connected) {
+			if (telegramHook.connected && cfg.getBoolean("enable-automated-chat-ids-update")) {
 				connectionLost = !telegramHook.getUpdate();
 			}
 		}, 0L, 10L);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,6 +20,9 @@ enable-deathmessages: true
 enable-chatmessages: true
 enable-advancement: true
 
+# this permits to turn on/off the automated add of new chat ids
+enable-automated-chat-ids-update: true
+
 # this will describe all types of advancements you want to be send on your telegram chat, be careful with 'recipes' type which can spam
 advancement-types: "adventure,husbandry,story,nether,end"
 


### PR DESCRIPTION
During my server lifecycle, I noticed sometimes some new chat ids configured during the startup.

the plugin was taking some other chat ids (not needed) and automatically configure them as direct targets of notifications.

I wanted to disable that "bug".